### PR TITLE
Add Redirect Checker to URL Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ List of links to the various checkers out there on the web for sites, domains, s
 
 | URL | Description | 💳 |
 | --- | ----------- | -- |
+| https://redirect-checker.autocompany.workers.dev | Analyze HTTP redirect chains (301/302/307/308), detect redirect loops, measure performance impact with multiple User-Agents including Googlebot. | Free |
 | https://urlscan.io | Find out what happens when a URL is accessed. | Free |
 
 ## Validation 👌


### PR DESCRIPTION
## Summary

Added [Redirect Checker](https://redirect-checker.autocompany.workers.dev) to the URL Analysis section.

## Description

Redirect Checker is a free HTTP redirect chain analyzer that helps developers and SEO professionals:

- **Trace complete redirect chains** (301, 302, 307, 308)
- **Detect redirect loops** before they cause problems
- **Measure performance impact** at each hop
- **Test with various User-Agents** including Googlebot, Bingbot, Mobile

## Why this is useful

Redirect chains impact both page load speed and SEO (link equity dilution). This tool helps identify and debug these issues quickly.

## Checklist

- [x] The tool is a checker service (not just a general web tool)
- [x] The tool is free to use
- [x] The URL follows the table format
- [x] Description is concise and accurate